### PR TITLE
FIX: creating sell offer

### DIFF
--- a/src/stellar/operations.ts
+++ b/src/stellar/operations.ts
@@ -160,8 +160,8 @@ export async function openSellOffer(
       Operation.manageSellOffer({
         selling: newAsset,
         buying: XLM,
-        amount: amount.toString(),
-        price: price.toString(),
+        amount: amount.toFixed(6),
+        price: price.toFixed(6),
         source: publicAddress,
         offerId: 0,
       })


### PR DESCRIPTION
During creating a sell offer, the following error appears:
```
TypeError: amount argument must be of type String, represent a positive number and have at most 7 digits after the decimal
```

I replaced the function `toString` with `toFixed` to avoid this error.