### PR TITLE
FEATURE: Token generation for audible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# if [[ "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "master"  ]] ; then
-#   # Proceed with the build
-exit 1;
+if [[ "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "master"  ]] ; then
+    # Proceed with the build
+    exit 1;
 
-# else
-#   # Don't build
-#   exit 0;
-# fi
+else
+    # Don't build
+    exit 0;
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-if [[ "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "master"  ]] ; then
-  # Proceed with the build
-  exit 1;
+# if [[ "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "master"  ]] ; then
+#   # Proceed with the build
+exit 1;
 
-else
-  # Don't build
-  exit 0;
-fi
+# else
+#   # Don't build
+#   exit 0;
+# fi

--- a/src/config/config.interface.ts
+++ b/src/config/config.interface.ts
@@ -15,4 +15,5 @@ export interface IConfig {
   NFT_STORAGE_API_KEY: string;
   STELLAR_NETWORK: string;
   PINATA_JWT: string;
+  AUDIBLE_SECRET: string;
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,4 +21,6 @@ export const Config: IConfig = {
   NFT_STORAGE_API_KEY: process.env.NFT_STORAGE_API_KEY || '',
   STELLAR_NETWORK: process.env.STELLAR_NETWORK || 'testnet',
   PINATA_JWT: process.env.PINATA_JWT || '',
+  AUDIBLE_SECRET:
+    Buffer.from(process.env.AUDIBLE_SECRET, 'base64').toString('ascii') || '',
 };

--- a/src/graphql/get-audible-token.ts
+++ b/src/graphql/get-audible-token.ts
@@ -1,0 +1,27 @@
+import * as jwt from 'jsonwebtoken';
+import { Config } from '../config';
+import Token from './types/token';
+import { getAuthenticatedUser } from 'src/auth/logic';
+
+const GetAudibleToken = {
+  type: Token,
+  args: {},
+  async resolve(_: any, __: any, ctx: any) {
+    const user = await getAuthenticatedUser(ctx);
+
+    // generates access token to audible magic service
+    // it's valid only 120 seconds to ensure that it isn't used for other purpose
+    const token = jwt.sign(
+      {
+        id: user.id,
+        email: user.email,
+      } as any,
+      Config.AUDIBLE_SECRET,
+      { algorithm: 'RS256', expiresIn: 120 }
+    );
+
+    return { token };
+  },
+};
+
+export default GetAudibleToken;

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -27,6 +27,7 @@ import GetIssuer from './get-issuer';
 import SetLastPlayedEntry from './set-last-played-entry';
 import SignInWithXDR from './sing-in-with-xdr';
 import ChangeWallet from './change-wallet';
+import GetAudibleToken from './get-audible-token';
 
 const Query = new GraphQLObjectType({
   name: 'Query',
@@ -44,6 +45,7 @@ const Query = new GraphQLObjectType({
       userLikes: UserLikes,
       xlmPrice: XLMPrice,
       getIssuer: GetIssuer,
+      getAudibleToken: GetAudibleToken,
     };
   },
 });

--- a/src/graphql/types/token.ts
+++ b/src/graphql/types/token.ts
@@ -1,0 +1,18 @@
+import { GraphQLObjectType, GraphQLString } from 'graphql';
+
+const Token: GraphQLObjectType = new GraphQLObjectType({
+  name: 'Token',
+  description: 'Object that contains access token',
+  fields: () => {
+    return {
+      token: {
+        type: GraphQLString,
+        resolve(token: any) {
+          return token.token;
+        },
+      },
+    };
+  },
+});
+
+export default Token;


### PR DESCRIPTION
We want to ensure that audible service will be accessible only to skyhitz users. Here's my proposal flow:
1. User authenticates in the skyhitz backend
2. User requests jwt access token to the audible service
3. Backend generates jwt access token valid for 120 seconds using RSA private key. We need to provide the `AUDIBLE_SECRET` env variable as a base64 encoded RSA private key.
4. User uses the obtained jwt to access audible service. Audible service authenticates user using RSA public key. We need to provide the `PUBLIC_KEY` env variable as a base64 encoded RSA public key.
5. User receives a response from audible service.

This pull request, adds the necessary query for 2 & 3 points in the proposed flow.