### PR TITLE
FIX: Added check if account exist on stellar

### DIFF
--- a/src/graphql/create-user-with-email.ts
+++ b/src/graphql/create-user-with-email.ts
@@ -7,6 +7,7 @@ import { createAndFundAccount } from '../stellar/operations';
 import { encrypt } from '../util/encryption';
 import { User } from '../util/types';
 import SuccessResponse from './types/success-response';
+import { getAccount, getConfig } from 'src/stellar/utils';
 
 const createUserWithEmail = {
   type: SuccessResponse,
@@ -48,6 +49,19 @@ const createUserWithEmail = {
     }
     if (res && res.publicKey === args.publicKey) {
       throw 'Public Key is connected to another account, please sign in.';
+    }
+
+    // check if provided publicKey account exists on stellar
+    if (args.publicKey) {
+      try {
+        await getAccount(args.publicKey);
+      } catch {
+        throw new Error(
+          `Provided public key does not exist on the Stellar ${
+            getConfig().network
+          } network. It must be created before it can be used to submit transactions.`
+        );
+      }
     }
 
     const newId = UniqueIdGenerator.generate();

--- a/src/graphql/create-user-with-email.ts
+++ b/src/graphql/create-user-with-email.ts
@@ -6,11 +6,14 @@ import { sendWelcomeEmail } from '../sendgrid/sendgrid';
 import { createAndFundAccount } from '../stellar/operations';
 import { encrypt } from '../util/encryption';
 import { User } from '../util/types';
-import SuccessResponse from './types/success-response';
 import { getAccount, getConfig } from 'src/stellar/utils';
+import { verifySourceSignatureOnXDR } from 'src/stellar';
+import ConditionalUser from './types/conditional-user';
+import * as jwt from 'jsonwebtoken';
+import { Config } from 'src/config';
 
 const createUserWithEmail = {
-  type: SuccessResponse,
+  type: ConditionalUser,
   args: {
     displayName: {
       type: new GraphQLNonNull(GraphQLString),
@@ -21,40 +24,51 @@ const createUserWithEmail = {
     username: {
       type: new GraphQLNonNull(GraphQLString),
     },
-    publicKey: {
+    signedXDR: {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
   async resolve(_: any, args: any, ctx: any) {
-    if (!args.email) {
+    const { displayName, email, username, signedXDR } = args;
+    if (!email) {
       throw `Email can't be an empty string`;
     }
-    if (!args.username) {
+    if (!username) {
       throw `Username can't be an empty string`;
     }
 
     // TODO: Make a proper fix
-    args.username = args.username.toLowerCase();
+    const usernameLowercase = username.toLowerCase();
+
+    // check if the provided signedXDR is valid and obtain publicKey
+    let publicKey;
+    if (signedXDR) {
+      const { verified, source } = verifySourceSignatureOnXDR(signedXDR);
+      if (!verified) {
+        throw 'Invalid signed XDR';
+      }
+      publicKey = source;
+    }
 
     const res = await getByUsernameOrEmailOrPublicKey(
-      args.username,
-      args.email,
-      args.publicKey
+      usernameLowercase,
+      email,
+      publicKey
     );
-    if (res && res.email === args.email) {
+    if (res && res.email === email) {
       throw 'Email already exists, please sign in.';
     }
-    if (res && res.username === args.username) {
+    if (res && res.username === usernameLowercase) {
       throw 'Username is taken.';
     }
-    if (res && res.publicKey === args.publicKey) {
+    if (res && res.publicKey === publicKey) {
       throw 'Public Key is connected to another account, please sign in.';
     }
 
     // check if provided publicKey account exists on stellar
-    if (args.publicKey) {
+    if (publicKey) {
       try {
-        await getAccount(args.publicKey);
+        await getAccount(publicKey);
       } catch {
         throw new Error(
           `Provided public key does not exist on the Stellar ${
@@ -68,14 +82,14 @@ const createUserWithEmail = {
 
     let user: User = {
       avatarUrl: '',
-      displayName: args.displayName,
+      displayName: displayName,
       description: '',
-      username: args.username,
-      email: args.email,
+      username: usernameLowercase,
+      email: email,
       version: 1,
       publishedAt: new Date().toISOString(),
       publishedAtTimestamp: Math.floor(new Date().getTime() / 1000),
-      publicKey: args.publicKey,
+      publicKey: publicKey,
       objectID: newId,
       id: newId,
       seed: '',
@@ -97,7 +111,27 @@ const createUserWithEmail = {
     await saveUser(user);
     sendWelcomeEmail(user.email);
 
-    return { success: true, message: 'User created.' };
+    // if the user already provided signedXDR and it was valid
+    // we can log in him already.
+    // otherwise user has to log in via email.
+    if (signedXDR) {
+      const token = jwt.sign(
+        {
+          id: user.id,
+          email: user.email,
+          version: user.version,
+        } as any,
+        Config.JWT_SECRET
+      );
+      user.jwt = token;
+      ctx.user = Promise.resolve(user);
+      return {
+        message: 'User created. You logged in successfully.',
+        user,
+      };
+    } else {
+      return { message: 'User created.' };
+    }
   },
 };
 

--- a/src/graphql/index-entry.ts
+++ b/src/graphql/index-entry.ts
@@ -11,7 +11,7 @@ import {
   ipfsProtocol,
 } from '../constants/constants';
 import Entry from './types/entry';
-import { pinIpfsFile } from 'src/util/pinata';
+import { pinIpfsFile } from '../util/pinata';
 
 const indexEntry = {
   type: Entry,

--- a/src/graphql/types/conditional-user.ts
+++ b/src/graphql/types/conditional-user.ts
@@ -1,0 +1,25 @@
+import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql';
+import { GraphQLUser } from './user';
+
+const ConditionalUser: GraphQLObjectType = new GraphQLObjectType({
+  name: 'ConditionalUser',
+  description: 'This is an ConditionalUser',
+  fields: () => {
+    return {
+      user: {
+        type: GraphQLUser,
+        resolve(object: any) {
+          return object.user;
+        },
+      },
+      message: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve(object: any) {
+          return object.message;
+        },
+      },
+    };
+  },
+});
+
+export default ConditionalUser;

--- a/src/graphql/update-user.ts
+++ b/src/graphql/update-user.ts
@@ -7,7 +7,7 @@ import {
   usersIndex,
 } from 'src/algolia/algolia';
 import { ipfsProtocol } from '../constants/constants';
-import { pinIpfsFile } from 'src/util/pinata';
+import { pinIpfsFile } from '../util/pinata';
 
 type UpdateUserArgs = {
   avatarUrl?: string | null;

--- a/src/stellar/utils.ts
+++ b/src/stellar/utils.ts
@@ -33,7 +33,7 @@ export function getConfig() {
 }
 
 export async function getAccount(publicKey) {
-  let account = await axios
+  const account = await axios
     .get(`${getConfig().horizonUrl}/accounts/${publicKey}`)
     .then(({ data }) => data);
   return account;


### PR DESCRIPTION
* I refactored create an account flow, so the user that wants to create an account via WalletConnect, could be already logged in. Instead of passing `publicKey`, they can now pass `signedXDR`. This also eliminates the case when the user could create an account with someone else's public key.
* Currently, we allow users to create an account with whatever public key they would provide, which can lead to some unwanted behavior later. I've added a check if the account exists on the stellar network, to avoid the situation when the account with a public key is created and the account is not existing on stellar.