### PR TITLE
Remove redundant awaits

### DIFF
--- a/src/algolia/algolia.ts
+++ b/src/algolia/algolia.ts
@@ -181,19 +181,19 @@ export async function likeMulti(userId, entryId) {
 
   try {
     await Promise.all([
-      await likesIndex.saveObject({
+      likesIndex.saveObject({
         objectID: `user${userId}entry${entryId}`,
         likeCount: likeCountNumber ? likeCountNumber : 0,
         entryId: entryId,
         userId: userId,
       }),
-      await likesIndex.saveObject({
+      likesIndex.saveObject({
         objectID: `entry${entryId}user${userId}`,
         likeCount: likeCountNumber ? likeCountNumber : 0,
         entryId: entryId,
         userId: userId,
       }),
-      await entriesIndex.partialUpdateObject({
+      entriesIndex.partialUpdateObject({
         objectID: entryId,
         likeCount: {
           _operation: 'Increment',
@@ -213,9 +213,9 @@ export async function unlikeMulti(userId, entryId) {
 
   try {
     await Promise.all([
-      await likesIndex.deleteObject(`user${userId}entry${entryId}`),
-      await likesIndex.deleteObject(`entry${entryId}user${userId}`),
-      await entriesIndex.partialUpdateObject({
+      likesIndex.deleteObject(`user${userId}entry${entryId}`),
+      likesIndex.deleteObject(`entry${entryId}user${userId}`),
+      entriesIndex.partialUpdateObject({
         objectID: entryId,
         likeCount: {
           _operation: 'Decrement',

--- a/src/stellar/operations.ts
+++ b/src/stellar/operations.ts
@@ -98,8 +98,8 @@ export async function accountExists(publicKey: string) {
 
 export async function buildTransactionWithFee(accountPublicKey) {
   const [account, fee] = await Promise.all([
-    await getAccount(accountPublicKey),
-    await getFee(),
+    getAccount(accountPublicKey),
+    getFee(),
   ]);
   return new TransactionBuilder(account, {
     fee: fee,


### PR DESCRIPTION
PR removes redundant `await` keywords from arrays of promises